### PR TITLE
Translate in-code comments from Japanese to English


### DIFF
--- a/test.rb
+++ b/test.rb
@@ -2,26 +2,26 @@
 
 require 'fileutils'
 
-# 指定したディレクトリ内のファイルを拡張子ごとに分類して表示する
+# List files in the specified directory and categorize them by extension
 def categorize_files(directory)
-  return puts "ディレクトリが存在しません: #{directory}" unless Dir.exist?(directory)
+  return puts "Directory does not exist: #{directory}" unless Dir.exist?(directory)
 
   file_categories = Hash.new { |hash, key| hash[key] = [] }
 
   Dir.foreach(directory) do |file|
-    next if File.directory?(file) # ディレクトリはスキップ
+    next if File.directory?(file) # Skip directories
     ext = File.extname(file).downcase
-    ext = 'なし' if ext.empty?
+    ext = 'none' if ext.empty?
     file_categories[ext] << file
   end
 
-  puts "ディレクトリ '#{directory}' 内のファイル一覧:"
+  puts "Files in directory '#{directory}':"
   file_categories.each do |ext, files|
     puts "[#{ext}]"
     files.each { |file| puts "  - #{file}" }
   end
 end
 
-# 実行
-directory_path = ARGV[0] || '.' # 引数がない場合はカレントディレクトリを対象
+# Execution
+directory_path = ARGV[0] || '.' # Use the current directory if no argument is provided
 categorize_files(directory_path)


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Translated in-code comments from Japanese to English.

- Improved code readability with English descriptions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.rb</strong><dd><code>Translate in-code comments and improve clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test.rb

<li>Translated all in-code comments from Japanese to English.<br> <li> Adjusted terminology for better clarity (e.g., 'none' instead of <br>'なし').<br> <li> Enhanced readability by providing English descriptions for execution <br>logic.


</details>


  </td>
  <td><a href="https://github.com/masutaka/sandbox/pull/96/files#diff-a7bce69e0d9f02a55d36f1b84429134d052557c4aaaeaf5caa6a0ca73d72c437">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>